### PR TITLE
#14 Fix interchanged names

### DIFF
--- a/src/ArcGraphModel.IO/ISA/Worksheet.fs
+++ b/src/ArcGraphModel.IO/ISA/Worksheet.fs
@@ -21,7 +21,7 @@ module Worksheet =
             token
         )
 
-    let parseColumns (worksheet : FsWorksheet) = 
+    let parseTableColumns (worksheet : FsWorksheet) = 
         let sheetName = Address.createWorksheetParam worksheet.Name
         worksheet.Tables.Head.Columns(worksheet.CellCollection)
         |> Seq.toList
@@ -36,7 +36,7 @@ module Worksheet =
             token
         )
 
-    let parseTableColumns (worksheet : FsWorksheet) = 
+    let parseColumns (worksheet : FsWorksheet) = 
         let sheetName = Address.createWorksheetParam worksheet.Name
         worksheet.Columns
         |> Seq.toList


### PR DESCRIPTION
In https://github.com/nfdi4plants/ArcGraphModel/blob/main/src/ArcGraphModel.IO/ISA/Worksheet.fs the function names `parseColumns` and `parseTableColumns` are mixed up. This PR

- renames them correctly
- fixes #14