### PR TITLE
#16 New IO parser(s)

### DIFF
--- a/playground.fsx
+++ b/playground.fsx
@@ -24,7 +24,9 @@ open System.Collections.Generic
 //#r "c:/repos/csbiology/fsspreadsheet/src/FsSpreadsheet/bin/Debug/netstandard2.0/FsSpreadsheet.dll"
 //#r "c:/repos/csbiology/fsspreadsheet/src/FsSpreadsheet.CsvIO/bin/Debug/netstandard2.0/FsSpreadsheet.CsvIO.dll"
 //#r "c:/repos/csbiology/fsspreadsheet/src/FsSpreadsheet.ExcelIO/bin/Debug/netstandard2.0/FsSpreadsheet.ExcelIO.dll"
-#r @"C:\Repos\nfdi4plants\ArcGraphModel\src\ArcGraphModel\bin\Debug\net6.0\ArcGraphModel.dll"
+//#r @"C:\Repos\nfdi4plants\ArcGraphModel\src\ArcGraphModel\bin\Debug\net6.0\ArcGraphModel.dll"
+#r @"C:\Repos\nfdi4plants\ArcGraphModel\src\ArcGraphModel\bin\Debug\netstandard2.0\ArcGraphModel.dll"
+#r @"C:\Repos\nfdi4plants\ArcGraphModel\src\ArcGraphModel.IO\bin\Debug\netstandard2.0\ArcGraphModel.IO.dll"
 //#r @"C:/Users/olive/.nuget/packages/fsharpaux/1.1.0/lib/net5.0/FSharpAux.dll"
 
 open FsSpreadsheet
@@ -36,6 +38,17 @@ open ArcGraphModel.TableTransform
 open FGLAux
 open ArcType
 
+
+
+let inves = FsWorkbook.fromXlsxFile @"C:\Users\revil\OneDrive\CSB-Stuff\NFDI\testARC30\isa.investigation.xlsx"
+
+let invesWs = FsWorkbook.getWorksheets inves |> Seq.head
+invesWs.RescanRows()
+invesWs.CellCollection
+invesWs.Rows
+
+let invesWsParsed = ArcGraphModel.IO.Worksheet.parseRowsAggregated invesWs
+let invesWsParsed = ArcGraphModel.IO.Worksheet.parseRowsFlat invesWs
 
 
 

--- a/src/ArcGraphModel.IO/ISA/Tokenization.fs
+++ b/src/ArcGraphModel.IO/ISA/Tokenization.fs
@@ -7,15 +7,12 @@ open KeyParser
 module Tokenization = 
     
     let convertTokens (line : FsCell seq) =
-        printfn "line: %A" line
         match line |> Seq.toList with
         | [] -> failwith "Cannot convert nothin"
         | key :: [] -> 
-            printfn "case key :: []"
             let f = parseKey [] key.Value
             [f (ParamValue.Value "")]
         | key :: cells ->
-            printfn "case key :: cells"
             let f = parseKey [] key.Value
             cells
             |> List.map (fun c -> 

--- a/src/ArcGraphModel.IO/ISA/Tokenization.fs
+++ b/src/ArcGraphModel.IO/ISA/Tokenization.fs
@@ -7,12 +7,15 @@ open KeyParser
 module Tokenization = 
     
     let convertTokens (line : FsCell seq) =
+        printfn "line: %A" line
         match line |> Seq.toList with
         | [] -> failwith "Cannot convert nothin"
         | key :: [] -> 
+            printfn "case key :: []"
             let f = parseKey [] key.Value
             [f (ParamValue.Value "")]
         | key :: cells ->
+            printfn "case key :: cells"
             let f = parseKey [] key.Value
             cells
             |> List.map (fun c -> 

--- a/src/ArcGraphModel.IO/ISA/Worksheet.fs
+++ b/src/ArcGraphModel.IO/ISA/Worksheet.fs
@@ -21,7 +21,7 @@ module Worksheet =
             token
         )
 
-    let parseColumns (worksheet : FsWorksheet) = 
+    let parseTableColumns (worksheet : FsWorksheet) = 
         let sheetName = Address.createWorksheetParam worksheet.Name
         worksheet.Tables.Head.Columns(worksheet.CellCollection)
         |> Seq.toList
@@ -36,7 +36,7 @@ module Worksheet =
             token
         )
 
-    let parseTableColumns (worksheet : FsWorksheet) = 
+    let parseColumns (worksheet : FsWorksheet) = 
         let sheetName = Address.createWorksheetParam worksheet.Name
         worksheet.Columns
         |> Seq.toList


### PR DESCRIPTION
Since new IO parsers are needed for [arc-validate](https://github.com/nfdi4plants/arc-validate/issues/31), this PR

- split parsing functions for rows, columns, and table columns into
  - aggregated and flat, where aggregated produces an ICvBase list (containing CvParams and CvContainers), and flat produces an IParam list (containing only CvParams)
- Closes #16